### PR TITLE
Bumping to Trino 364

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM openjdk:11-jre-slim
 
-ARG PRESTO_VERSION="363"
+ARG PRESTO_VERSION="364"
 ARG MIRROR="https://repo1.maven.org/maven2/io/trino"
 ARG PRESTO_BIN="${MIRROR}/trino-server/${PRESTO_VERSION}/trino-server-${PRESTO_VERSION}.tar.gz"
 ARG PRESTO_CLI_BIN="${MIRROR}/trino-cli/${PRESTO_VERSION}/trino-cli-${PRESTO_VERSION}-executable.jar"


### PR DESCRIPTION
Trino 364 out as [of 4 days ago](https://github.com/trinodb/trino/releases/tag/364).  Scanned [the release notes](https://github.com/trinodb/trino/issues/9534), and doesn't look like there any breaking changes.

Need an ES bug fix (specifically, [this one](https://github.com/trinodb/trino/commit/e90f87f47bb1abecf2a3fd63b70e908287c057c2)).